### PR TITLE
Added support for GL_UNSIGNED_SHORT_4_4_4_4 in GL_RGBA

### DIFF
--- a/Modules/Image/Src/tImageKTX.cpp
+++ b/Modules/Image/Src/tImageKTX.cpp
@@ -234,6 +234,7 @@ void tKTX::GetFormatInfo_FromGLFormat(tPixelFormat& format, tColourProfile& prof
 		C(RGBA_INTEGER):
 			switch (glType)
 			{
+				C(UNSIGNED_SHORT_4_4_4_4):		F(B4A4R4G4)									T(UINT)		break;
 				C(UNSIGNED_BYTE):				F(R8G8B8A8)									T(UINT)		break;
 				C(HALF_FLOAT):					F(R16G16B16A16f)	P(HDRa)					T(SFLOAT)	break;
 				C(FLOAT):						F(R32G32B32A32f)	P(HDRa)					T(SFLOAT)	break;


### PR DESCRIPTION
Added support for GL_UNSIGNED_SHORT_4_4_4_4 to GL_RGBA type, maybe it's wrong, but it worked correctly with my texture of this type.
There is just such a file in the attached archive, which I managed to convert using your view to png.
[File_test.zip](https://github.com/bluescan/tacent/files/13888946/File_test.zip)
